### PR TITLE
🚀 Optimize IPicture with better string memory management

### DIFF
--- a/displayable/IDisplayable.hpp
+++ b/displayable/IDisplayable.hpp
@@ -8,12 +8,13 @@
 
 #pragma once
 #include "../utils/ICoordinate.hpp"
+#include <memory>
 
 class IDisplayable {
 public:
     virtual ~IDisplayable() = default;
-    virtual ICoordinate getPosition() = 0;
-    virtual int getSize() = 0;
-    virtual void setPosition(ICoordinate position) = 0;
+    virtual const std::unique_ptr<ICoordinate> &getPosition() const = 0;
+    virtual int getSize() const = 0;
+    virtual void setPosition(ICoordinate &position) = 0;
     virtual void setSize(int size) = 0;
 };

--- a/displayable/entities/IEntity.hpp
+++ b/displayable/entities/IEntity.hpp
@@ -14,6 +14,6 @@
 class IEntity: public IDisplayable {
 public:
     virtual ~IEntity() = default;
-    virtual std::shared_ptr<ISprite> getSprite() = 0;
-    virtual void setSprite(std::unique_ptr<ISprite> sprite) = 0;
+    virtual const std::unique_ptr<ISprite> &getSprite() const = 0;
+    virtual void setSprite(ISprite &sprite) = 0;
 };

--- a/displayable/entities/ISprite.hpp
+++ b/displayable/entities/ISprite.hpp
@@ -13,6 +13,6 @@
 class ISprite {
 public:
     virtual ~ISprite() = default;
-    virtual std::shared_ptr<IPicture> getPicture() = 0;
+    virtual const std::unique_ptr<IPicture> &getPicture() const = 0;
     virtual void setPicture(std::unique_ptr<IPicture> picture) = 0;
 };

--- a/displayable/entities/ISprite.hpp
+++ b/displayable/entities/ISprite.hpp
@@ -12,6 +12,7 @@
 
 class ISprite {
 public:
+    virtual ~ISprite() = default;
     virtual std::shared_ptr<IPicture> getPicture() = 0;
     virtual void setPicture(std::unique_ptr<IPicture> picture) = 0;
 };

--- a/displayable/primitives/IPrimitive.hpp
+++ b/displayable/primitives/IPrimitive.hpp
@@ -14,5 +14,5 @@
 class IPrimitive: public IDisplayable {
 public:
     virtual ~IPrimitive() = default;
-    virtual IColor getColor() = 0;
+    virtual const std::unique_ptr<IColor> &getColor() const = 0;
 };

--- a/errors/IDriverError.hpp
+++ b/errors/IDriverError.hpp
@@ -13,6 +13,6 @@ class IDriverError: public IError {
 public:
     virtual ~IDriverError() = default;
     virtual int getCode() const = 0;
-    virtual std::shared_ptr<IDriver> getDriver() const = 0;
+    virtual const std::unique_ptr<IDriver> &getDriver() const = 0;
     virtual const char *what() const noexcept = 0;
 };

--- a/errors/IGameError.hpp
+++ b/errors/IGameError.hpp
@@ -13,6 +13,6 @@ class IGameError: public IError {
 public:
     virtual ~IGameError() = default;
     virtual int getCode() const = 0;
-    virtual std::shared_ptr<IGame> getGame() const = 0;
+    virtual const std::unique_ptr<IGame> &getGame() const = 0;
     virtual const char *what() const noexcept = 0;
 };

--- a/events/IEvent.hpp
+++ b/events/IEvent.hpp
@@ -25,7 +25,7 @@ public:
     virtual ~IEvent() = default;
     virtual EventType getType() = 0;
     virtual EventKey getKey() = 0;
-    virtual ICoordinate getPosition() = 0;
+    virtual std::unique_ptr<ICoordinate> &getPosition() = 0;
 };
 
 typedef void (*EventCallback)(std::shared_ptr<IEvent> event);

--- a/utils/ICanRotate.hpp
+++ b/utils/ICanRotate.hpp
@@ -17,6 +17,6 @@ const float RIGHT = 0;
 
 public:
     virtual ~ICanRotate() = default;
-    virtual float getRotation() = 0;
+    virtual float getRotation() const = 0;
     virtual void setRotation(float angle) = 0;
 };

--- a/utils/ICoordinate.hpp
+++ b/utils/ICoordinate.hpp
@@ -10,6 +10,7 @@
 
 class ICoordinate {
 public:
+    virtual ~ICoordinate() = default;
     virtual int getX() const = 0;
     virtual int getY() const = 0;
     virtual void setX(int x) = 0;

--- a/utils/IPicture.hpp
+++ b/utils/IPicture.hpp
@@ -11,6 +11,7 @@
 
 class IPicture {
 public:
-    virtual std::string getPath() const = 0;
-    virtual void setPath(std::string path) = 0;
+    virtual ~IPicture() = default;
+    virtual const std::string &getPath() const = 0;
+    virtual void setPath(const std::string &path) = 0;
 };

--- a/utils/IPicture.hpp
+++ b/utils/IPicture.hpp
@@ -11,6 +11,6 @@
 
 class IPicture {
 public:
-    virtual std::string getPath() = 0;
+    virtual std::string getPath() const = 0;
     virtual void setPath(std::string path) = 0;
 };


### PR DESCRIPTION
I changed IPicture function so they don't copy over and over strings since it's a bad practice.