### PR TITLE
:bug: Add missing pragma once

### DIFF
--- a/errors/IDriverError.hpp
+++ b/errors/IDriverError.hpp
@@ -6,6 +6,7 @@
 ** You can even have multiple lines if you want !
 */
 
+#pragma once
 #include "../IDriver.hpp"
 #include "IError.hpp"
 

--- a/errors/IError.hpp
+++ b/errors/IError.hpp
@@ -6,6 +6,7 @@
 ** You can even have multiple lines if you want !
 */
 
+#pragma once
 #include <string>
 #include <memory>
 #include <exception>

--- a/errors/IGameError.hpp
+++ b/errors/IGameError.hpp
@@ -6,6 +6,7 @@
 ** You can even have multiple lines if you want !
 */
 
+#pragma once
 #include "../IGame.hpp"
 #include "IError.hpp"
 


### PR DESCRIPTION
There was missing `#pragma once` in Error header’s file.