### PR TITLE
:recycle: Add or Remove smart pointers based on context

### DIFF
--- a/IArcade.hpp
+++ b/IArcade.hpp
@@ -16,7 +16,7 @@ public:
     virtual ~IArcade() = default;
 
     // Driver functions for games
-    virtual void display(std::shared_ptr<IDisplayable> displayable) = 0;
+    virtual void display(const IDisplayable &displayable) = 0;
     virtual void flipFrame() = 0;
     virtual void bindEvent(IEvent::EventType type, EventKey key, EventCallback callback) = 0;
     virtual void setPreferredSize(std::size_t width, std::size_t height) = 0;

--- a/IDriver.hpp
+++ b/IDriver.hpp
@@ -15,7 +15,7 @@
 class IDriver {
 public:
     virtual ~IDriver() = default;
-    virtual void display(std::shared_ptr<IDisplayable> displayable) = 0;
+    virtual void display(const IDisplayable &displayable) = 0;
     virtual void flipFrame() = 0;
     virtual void bindEvent(IEvent::EventType type, EventKey key, EventCallback callback) = 0;
     virtual void setPreferredSize(std::size_t width, std::size_t height) = 0;

--- a/IGame.hpp
+++ b/IGame.hpp
@@ -13,7 +13,7 @@
 class IGame {
 public:
     virtual ~IGame() = default;
-    virtual void init(std::shared_ptr<IArcade> arcade) = 0;
+    virtual void init(IArcade &arcade) = 0;
     virtual void start() = 0;
     virtual void run() = 0;
     [[nodiscard]] virtual int getScore() = 0;

--- a/displayable/IDisplayable.hpp
+++ b/displayable/IDisplayable.hpp
@@ -13,8 +13,9 @@
 class IDisplayable {
 public:
     virtual ~IDisplayable() = default;
-    [[nodiscard]] virtual const std::unique_ptr<ICoordinate> &getPosition() const = 0;
+    [[nodiscard]] virtual const ICoordinate &getPosition() const = 0;
     [[nodiscard]] virtual int getSize() const = 0;
-    virtual void setPosition(ICoordinate &position) = 0;
+    virtual void setPosition(const ICoordinate &position) = 0;
+    virtual void setPosition(std::unique_ptr<ICoordinate> position) = 0;
     virtual void setSize(int size) = 0;
 };

--- a/displayable/entities/IEntity.hpp
+++ b/displayable/entities/IEntity.hpp
@@ -14,6 +14,7 @@
 class IEntity: public virtual IDisplayable {
 public:
     ~IEntity() override = default;
-    [[nodiscard]] virtual const std::unique_ptr<ISprite> &getSprite() const = 0;
-    virtual void setSprite(ISprite &sprite) = 0;
+    [[nodiscard]] virtual const ISprite &getSprite() const = 0;
+    virtual void setSprite(const ISprite &sprite) = 0;
+    virtual void setSprite(std::unique_ptr<ISprite> sprite) = 0;
 };

--- a/displayable/entities/ISprite.hpp
+++ b/displayable/entities/ISprite.hpp
@@ -13,6 +13,7 @@
 class ISprite {
 public:
     virtual ~ISprite() = default;
-    [[nodiscard]] virtual const std::unique_ptr<IPicture> &getPicture() const = 0;
+    [[nodiscard]] virtual const IPicture &getPicture() const = 0;
+    virtual void setPicture(const IPicture &picture) = 0;
     virtual void setPicture(std::unique_ptr<IPicture> picture) = 0;
 };

--- a/displayable/primitives/ICircle.hpp
+++ b/displayable/primitives/ICircle.hpp
@@ -13,6 +13,6 @@
 class ICircle: public virtual IPrimitive {
 public:
     ~ICircle() override = default;
-    [[nodiscard]] virtual size_t getRadius() const = 0;
-    virtual void setRadius(size_t radius) = 0;
+    [[nodiscard]] virtual std::size_t getRadius() const = 0;
+    virtual void setRadius(std::size_t radius) = 0;
 };

--- a/displayable/primitives/IPrimitive.hpp
+++ b/displayable/primitives/IPrimitive.hpp
@@ -14,5 +14,5 @@
 class IPrimitive: public virtual IDisplayable {
 public:
     ~IPrimitive() override = default;
-    [[nodiscard]] virtual const std::unique_ptr<IColor> &getColor() const = 0;
+    [[nodiscard]] virtual const IColor &getColor() const = 0;
 };

--- a/displayable/primitives/ISquare.hpp
+++ b/displayable/primitives/ISquare.hpp
@@ -13,8 +13,8 @@
 class ISquare: public virtual IPrimitive {
 public:
     ~ISquare() override = default;
-    virtual size_t getWidth() const = 0;
-    virtual size_t getHeight() const = 0;
-    virtual void setWidth(size_t width) = 0;
-    virtual void setHeight(size_t height) = 0;
+    virtual std::size_t getWidth() const = 0;
+    virtual std::size_t getHeight() const = 0;
+    virtual void setWidth(std::size_t width) = 0;
+    virtual void setHeight(std::size_t height) = 0;
 };

--- a/errors/IDriverError.hpp
+++ b/errors/IDriverError.hpp
@@ -13,5 +13,5 @@
 class IDriverError: public virtual IError {
 public:
     ~IDriverError() override = default;
-    virtual const std::unique_ptr<IDriver> &getDriver() const = 0;
+    [[nodiscard]] virtual const IDriver &getDriver() const = 0;
 };

--- a/errors/IGameError.hpp
+++ b/errors/IGameError.hpp
@@ -13,5 +13,5 @@
 class IGameError: public virtual IError {
 public:
     ~IGameError() override = default;
-    [[nodiscard]]  virtual const std::unique_ptr<IGame> &getGame() const = 0;
+    [[nodiscard]] virtual const IGame &getGame() const = 0;
 };

--- a/events/IEvent.hpp
+++ b/events/IEvent.hpp
@@ -26,7 +26,7 @@ public:
     virtual ~IEvent() = default;
     [[nodiscard]] virtual EventType getType() = 0;
     [[nodiscard]] virtual EventKey getKey() = 0;
-    [[nodiscard]] virtual std::unique_ptr<ICoordinate> &getPosition() = 0;
+    [[nodiscard]] virtual const ICoordinate &getPosition() = 0;
 };
 
-typedef std::function<void(IEvent &)> EventCallback;
+typedef std::function<void(const IEvent &)> EventCallback;


### PR DESCRIPTION
The main use case of smart pointers is for ownership management. In many cases this features is not useful for us and since it's easier to work with references I updated our code to do so.

Moreover, we were not consistent with our use of smart pointers, some setters were using it while other were with references. I updated all setters (should be so), so they now exist in two versions, with and without smart pointer.