### PR TITLE
:art:  Add color support to IDisplayable interface

### DIFF
--- a/displayable/IDisplayable.hpp
+++ b/displayable/IDisplayable.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 #include "../utils/ICoordinate.hpp"
+#include "../utils/IColor.hpp"
 #include <memory>
 
 class IDisplayable {
@@ -19,4 +20,7 @@ public:
     virtual void setPosition(std::unique_ptr<ICoordinate> position) = 0;
     virtual void setSize(float size) = 0;
     [[nodiscard]] virtual char getReplacingChar() const = 0;
+    [[nodiscard]] virtual const IColor &getColor() const = 0;
+    virtual void setColor(const IColor &color) = 0;
+    virtual void setColor(std::unique_ptr<IColor> color) = 0;
 };

--- a/displayable/primitives/IPrimitive.hpp
+++ b/displayable/primitives/IPrimitive.hpp
@@ -9,12 +9,8 @@
 #pragma once
 #include <memory>
 #include "../IDisplayable.hpp"
-#include "../../utils/IColor.hpp"
 
 class IPrimitive: public virtual IDisplayable {
 public:
-    ~IPrimitive() override = default;
-    [[nodiscard]] virtual const IColor &getColor() const = 0;
-    virtual void setColor(const IColor &color) = 0;
-    virtual void setColor(std::unique_ptr<IColor> color) = 0;
+    ~IPrimitive() override = default;;
 };

--- a/displayable/primitives/IPrimitive.hpp
+++ b/displayable/primitives/IPrimitive.hpp
@@ -12,5 +12,5 @@
 
 class IPrimitive: public virtual IDisplayable {
 public:
-    ~IPrimitive() override = default;;
+    ~IPrimitive() override = default;
 };


### PR DESCRIPTION
I moved the getters and setters method for the color from [IPrimitive](https://github.com/epitech-mirroring/ArcadeShared/blob/main/displayable/primitives/IPrimitive.hpp) to [IDisplayable](https://github.com/epitech-mirroring/ArcadeShared/blob/main/displayable/IDisplayable.hpp) 